### PR TITLE
Add copy button to endpoints

### DIFF
--- a/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/MethodEndpoint/index.tsx
+++ b/packages/docusaurus-theme-openapi/src/theme/ApiDemoPanel/MethodEndpoint/index.tsx
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
-import React from "react";
+import React, { useState } from "react";
+
+import FloatingButton from "../FloatingButton";
 
 function colorForMethod(method: string) {
   switch (method.toLowerCase()) {
@@ -28,18 +30,30 @@ interface Props {
 }
 
 function MethodEndpoint({ method, path }: Props) {
+  const [copyText, setCopyText] = useState("Copy");
+
+  const handleCopy = () => {
+    setCopyText("Copied");
+    setTimeout(() => setCopyText("Copy"), 2000);
+    navigator.clipboard.writeText(
+      `${method.toUpperCase()} ${path.replace(/\{([a-z0-9-_]+)\}/gi, ":$1")}`
+    );
+  };
+
   return (
-    <pre
-      style={{
-        background: "var(--openapi-card-background-color)",
-        borderRadius: "var(--openapi-card-border-radius)",
-      }}
-    >
-      <span style={{ color: colorForMethod(method) }}>
-        {method.toUpperCase()}
-      </span>{" "}
-      <span>{path.replace(/{([a-z0-9-_]+)}/gi, ":$1")}</span>
-    </pre>
+    <FloatingButton label={copyText} onClick={handleCopy}>
+      <pre
+        style={{
+          background: "var(--openapi-card-background-color)",
+          borderRadius: "var(--openapi-card-border-radius)",
+        }}
+      >
+        <span style={{ color: colorForMethod(method) }}>
+          {method.toUpperCase()}
+        </span>{" "}
+        <span>{path.replace(/\{([a-z0-9-_]+)\}/gi, ":$1")}</span>
+      </pre>
+    </FloatingButton>
   );
 }
 


### PR DESCRIPTION
## Summary
- add copy button overlay to method endpoint display

## Testing
- `yarn test` *(fails: package isn't present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685afa79c5848322b5a681db610322c3